### PR TITLE
refactor(dashboard): Implement asynchronous asset detail view #5

### DIFF
--- a/app/Http/Controllers/OptionsController.php
+++ b/app/Http/Controllers/OptionsController.php
@@ -22,8 +22,9 @@ class OptionsController extends Controller
         $results = $this->marketDataService->process($request->input('market_data'));
         return Inertia::render('Dashboard', [
             'underlying' => $results['underlying'] ?? null,
-            'options' => $results['options'] ?? [],
+            'options'    => $results['options'] ?? [],
             'strategies' => $results['strategies'] ?? [],
+            'tab'        => request()->get('tab', 'options'),
         ]);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,37 +2,29 @@
 
 namespace App\Http\Middleware;
 
+use App\Services\DashboardDataService;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 
 class HandleInertiaRequests extends Middleware
 {
-    /**
-     * The root template that is loaded on the first page visit.
-     *
-     * @var string
-     */
     protected $rootView = 'app';
 
-    /**
-     * Determine the current asset version.
-     */
     public function version(Request $request): ?string
     {
         return parent::version($request);
     }
 
-    /**
-     * Define the props that are shared by default.
-     *
-     * @return array<string, mixed>
-     */
     public function share(Request $request): array
     {
         return [
             ...parent::share($request),
             'auth' => [
                 'user' => $request->user(),
+            ],
+            'dashboardLists' => fn () => app(DashboardDataService::class)->getDashboardLists(),
+            'marketData' => fn () => [
+                'fearAndGreed' => app(\App\Services\MarketServices\FearGreedIndexService::class)->fetch(),
             ],
         ];
     }

--- a/app/Services/DashboardDataService.php
+++ b/app/Services/DashboardDataService.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Services;
+
+use App\Repositories\MacdRepository;
+use App\Services\StockServices\Indicators\RsiService;
+use App\Services\StockServices\Prices\StockAnalysisApiService;
+
+class DashboardDataService
+{
+    public function __construct(
+        private RsiService $rsiService,
+        private MacdRepository $macdRepository,
+        private StockAnalysisApiService $stockAnalysisService
+    ) {}
+
+    public function getDashboardLists(): array
+    {
+        return cache()->remember('dashboard_lists', now()->addMinutes(5), function () {
+            $tickers = config('tickers.spy', []);
+            $cryptos = config('tickers.criptoList', []);
+
+            $rsiData = $this->rsiService->getLatestRsiForTickers($tickers);
+            $macdData = $this->macdRepository->getLatestMacdForTickers($tickers);
+            $lastTwoPrices = $this->stockAnalysisService->fetchLastTwoPricesForAllTickersNew($tickers);
+
+            $stocksList = [];
+            foreach ($tickers as $ticker) {
+                $prices = $lastTwoPrices[$ticker] ?? [];
+                $lastTwoCloses = $this->getLastTwoCloses($prices);
+
+                $stocksList[] = [
+                    'symbol' => $ticker,
+                    'rsi' => $rsiData[$ticker]['value'] ?? null,
+                    'macd' => $macdData[$ticker]->value ?? null,
+                    'price' => $lastTwoCloses['lastClose'] ?? null,
+                    'changePercent' => $this->calculatePercentageChange($lastTwoCloses),
+                ];
+            }
+
+            $cryptoList = [];
+            foreach ($cryptos as $crypto) {
+                $cryptoList[] = [
+                    'symbol' => $crypto,
+                    'rsi' => null,
+                    'macd' => null,
+                    'price' => null,
+                    'changePercent' => null,
+                ];
+            }
+
+            return [
+                'stocksList' => $stocksList,
+                'cryptoList' => $cryptoList,
+            ];
+        });
+    }
+
+    private function getLastTwoCloses(array $stockData): array
+    {
+        if (empty($stockData['data']) || count($stockData['data']) < 2) {
+            return [];
+        }
+        $last = end($stockData['data']);
+        $prev = prev($stockData['data']);
+        return [
+            'lastClose' => $last['close'] ?? null,
+            'prevClose' => $prev['close'] ?? null,
+        ];
+    }
+
+    private function calculatePercentageChange(array $lastTwoCloses): ?float
+    {
+        if (!isset($lastTwoCloses['lastClose'], $lastTwoCloses['prevClose']) || $lastTwoCloses['prevClose'] == 0) {
+            return null;
+        }
+        return (($lastTwoCloses['lastClose'] - $lastTwoCloses['prevClose']) / $lastTwoCloses['prevClose']) * 100;
+    }
+}

--- a/resources/js/Components/BaseDashboardTable.vue
+++ b/resources/js/Components/BaseDashboardTable.vue
@@ -12,6 +12,8 @@ import { Search } from 'lucide-vue-next'
 import type { StockOrCryptoItem } from '@/types/stock'
 import { getColumns } from '@/composables/useStockTable'
 
+defineEmits(['view-item'])
+
 const props = defineProps<{
   data: StockOrCryptoItem[],
   noResultsMessage?: string
@@ -104,7 +106,7 @@ function rowLinkStyle() {
         <TableBody>
           <template v-if="table.getRowModel().rows?.length">
             <template v-for="row in table.getRowModel().rows" :key="row.id">
-              <TableRow :class="rowLinkStyle()" @click="$inertia.visit(`/stocks?symbol=${row.original.symbol}`)" class="border-0">
+              <TableRow :class="rowLinkStyle()" @click="$emit('view-item', row.original.symbol)" class="border-0">
                 <TableCell v-for="cell in row.getVisibleCells()" :key="cell.id" class="p-4 border-b border-[hsl(var(--border))]">
                   <FlexRender :render="cell.column.columnDef.cell" :props="cell.getContext()" />
                 </TableCell>

--- a/resources/js/Components/DashboardTabs.vue
+++ b/resources/js/Components/DashboardTabs.vue
@@ -1,94 +1,42 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import { usePage } from '@inertiajs/vue3'
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/Components/ui/tabs'
-import CryptoTable from './CryptoTable.vue'
-import StocksTable from './StocksTable.vue'
-import FgiCard from '@/Components/Fear&Greed.vue'
-import BondsTab from '../Pages/Bonds/BondsTab.vue'
-import OptionsTab from '../Pages/Options/OptionsTab.vue'
-import WebhookTab from '../Pages/Options/WebhookTab.vue'
+import { BitcoinIcon, LineChartIcon, BanknoteIcon, FlagIcon, PuzzleIcon, WebhookIcon } from 'lucide-vue-next'
 
-import {
-    LineChartIcon,
-    FlagIcon,
-    BanknoteIcon,
-    PuzzleIcon,
-    BitcoinIcon,
-    WebhookIcon
-} from 'lucide-vue-next'
+const emit = defineEmits(['update:modelValue'])
 
-const props = defineProps<{
-    cryptoList: any[]
-    stocksList: any[]
-    marketData: { fearAndGreed: any | null }
-}>()
-
-const page = usePage()
-const tabFromQuery = computed(() => {
-    const url = page.url
-    const queryString = url.split('?')[1] || ''
-    const params = new URLSearchParams(queryString)
-    return params.get('tab') || 'crypto'
-})
+function onTabChange(value: string | number) {
+    emit('update:modelValue', value)
+}
 </script>
 
 <template>
-    <Tabs :default-value="tabFromQuery" class="w-full">
+    <Tabs default-value="crypto" @update:model-value="onTabChange" class="w-full">
         <TabsList class="mb-4 flex h-auto justify-start overflow-x-auto rounded-t-lg bg-[hsl(var(--secondary))] p-0">
-            <TabsTrigger
-                value="crypto"
-                class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4"
-            >
-                <BitcoinIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" />
-                Cryptos
+             <TabsTrigger value="crypto" class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4">
+                <BitcoinIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" /> Cryptos
             </TabsTrigger>
-            <TabsTrigger
-                value="stocks"
-                class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4"
-            >
-                <LineChartIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" />
-                Stocks
+            <TabsTrigger value="stocks" class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4">
+                <LineChartIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" /> Stocks
             </TabsTrigger>
-            <TabsTrigger
-                value="merval"
-                class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4"
-            >
-                <FlagIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" />
-                Merval
+            <TabsTrigger value="bonds" class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4">
+                <BanknoteIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" />Bonds
             </TabsTrigger>
-            <TabsTrigger
-                value="bonds"
-                class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4"
-            >
-                <BanknoteIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" />
-                Bonds
+            <TabsTrigger value="merval" class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4">
+                <FlagIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" />Merval
             </TabsTrigger>
-            <TabsTrigger
-                value="options"
-                class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4"
-            >
-                <PuzzleIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" />
-                Options
-            </TabsTrigger>
-            <TabsTrigger
-                value="webhook"
-                class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4"
-            >
-                <WebhookIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" />
-                Webhook
-            </TabsTrigger>
-        </TabsList>
+                  <TabsTrigger value="options" class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4">
+          <PuzzleIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" />Options
+      </TabsTrigger>
+      <TabsTrigger value="webhook" class="asset-tab-active-indicator relative flex-1 rounded-none px-2 py-3 text-[hsl(var(--secondary-foreground))] shadow-none hover:bg-[hsl(var(--nav-border))] focus-visible:ring-0 data-[state=active]:bg-transparent data-[state=active]:text-[hsl(var(--secondary-foreground))] data-[state=active]:shadow-none md:px-4">
+          <WebhookIcon class="mb-0.5 mr-1 h-4 w-4 md:mr-2" />Webhook
+      </TabsTrigger>
+            </TabsList>
 
-        <TabsContent value="crypto"><CryptoTable :data="props.cryptoList" /></TabsContent>
-        <TabsContent value="stocks">
-          <div class="max-w-4xl mx-auto">
-            <FgiCard :data="props.marketData.fearAndGreed" />
-          </div>
-          <StocksTable :data="props.stocksList" />
-        </TabsContent>
-        <TabsContent value="bonds"><BondsTab /></TabsContent>
-        <TabsContent value="options"><OptionsTab /></TabsContent>
-        <TabsContent value="webhook"><WebhookTab /></TabsContent>
+        <TabsContent value="crypto"><slot name="crypto" /></TabsContent>
+        <TabsContent value="stocks"><slot name="stocks" /></TabsContent>
+        <TabsContent value="merval"><slot name="merval" /></TabsContent>
+        <TabsContent value="bonds"><slot name="bonds" /></TabsContent>
+        <TabsContent value="options"><slot name="options" /></TabsContent>
+        <TabsContent value="webhook"><slot name="webhook" /></TabsContent>
     </Tabs>
 </template>

--- a/resources/js/Components/StockDetail.vue
+++ b/resources/js/Components/StockDetail.vue
@@ -1,17 +1,14 @@
 <script setup lang="ts">
 import { ref, computed, defineProps } from 'vue'
 import { Head } from '@inertiajs/vue3'
-import DashboardLayout from '@/Layouts/DashboardLayout.vue'
-import ChartTab from './Tabs/ChartTab.vue'
-import PricesTab from './Tabs/PricesTab.vue'
-import TechnicalTab from './Tabs/TechnicalTab.vue'
-import FinancialTab from './Tabs/FinancialTab.vue'
+import ChartTab from '@/Pages/Stocks/Tabs/ChartTab.vue'
+import PricesTab from '@/Pages/Stocks/Tabs/PricesTab.vue'
+import TechnicalTab from '@/Pages/Stocks/Tabs/TechnicalTab.vue'
+import FinancialTab from '@/Pages/Stocks/Tabs/FinancialTab.vue'
 import { Button } from '@/Components/ui/button'
 import { Card, CardContent } from '@/Components/ui/card' 
 
 import type { StockData, RsiItem, MacdItem, CompanyData, FinancialStatementItem, FinancialRecord } from '@/types/stock'
-
-defineOptions({ layout: DashboardLayout })
 
 const props = defineProps<{
     symbol: string

--- a/resources/js/Components/StocksTable.vue
+++ b/resources/js/Components/StocksTable.vue
@@ -3,8 +3,14 @@ import BaseDashboardTable from '@/Components/BaseDashboardTable.vue'
 import type { StockOrCryptoItem } from '@/types/stock'
 
 const props = defineProps<{ data: StockOrCryptoItem[] }>()
+
+defineEmits(['view-stock'])
 </script>
 
 <template>
-  <BaseDashboardTable :data="data" noResultsMessage="No stocks results." />
+  <BaseDashboardTable 
+    :data="data" 
+    noResultsMessage="No stocks results."
+    @view-item="$emit('view-stock', $event)" 
+  />
 </template>

--- a/resources/js/Layouts/DashboardLayout.vue
+++ b/resources/js/Layouts/DashboardLayout.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+import { usePage } from '@inertiajs/vue3'
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
+import DashboardTabs from '@/Components/DashboardTabs.vue'
+import type { PageProps } from '@inertiajs/core';
+
+const page = usePage<PageProps>()
+
+</script>
+
+<template>
+  <AuthenticatedLayout>
+    <div class="py-12">
+      <div class="mx-auto max-w-7xl sm:px-6 lg:px-8 space-y-4">
+        <DashboardTabs
+          :crypto-list="page.props.dashboardLists.cryptoList"
+          :stocks-list="page.props.dashboardLists.stocksList"
+          :market-data="page.props.marketData"
+        />
+        <main>
+          <slot />
+        </main>
+      </div>
+    </div>
+  </AuthenticatedLayout>
+</template>

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -1,24 +1,75 @@
 <script setup lang="ts">
+import { ref, defineAsyncComponent } from 'vue'
+import axios from 'axios'
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
 import DashboardTabs from '@/Components/DashboardTabs.vue'
+import StocksTable from '@/Components/StocksTable.vue'
+import CryptoTable from '@/Components/CryptoTable.vue'
+import BondsTab from '@/Pages/Bonds/BondsTab.vue'
+import OptionsTab from '@/Pages/Options/OptionsTab.vue'
+import WebhookTab from '@/Pages/Options/WebhookTab.vue'
+import FgiCard from '@/Components/Fear&Greed.vue'
+import { usePage, Head } from '@inertiajs/vue3'
 
-const props = defineProps<{
-  cryptoList: any[],
-  stocksList: any[],
-  marketData: { fearAndGreed: any | null },
-}>()
+const StockDetail = defineAsyncComponent(() => import('@/Components/StockDetail.vue'))
+
+const page = usePage()
+
+const selectedStock = ref<any>(null) 
+const isLoadingStock = ref(false)
+
+async function viewStockDetail(symbol: string) {
+    isLoadingStock.value = true
+    try {
+        const response = await axios.get(`/stock-data/${symbol}`);
+        selectedStock.value = response.data
+    } catch (error) {
+        console.error("Error:", error);
+    } finally {
+        isLoadingStock.value = false
+    }
+}
+
+function clearSelectedStock() {
+    selectedStock.value = null
+}
 </script>
 
 <template>
-  <AuthenticatedLayout>
-    <div class="py-12">
-      <div class="mx-auto max-w-7xl sm:px-6 lg:px-8 space-y-4">
-        <DashboardTabs
-          :crypto-list="cryptoList"
-          :stocks-list="stocksList"
-          :market-data="props.marketData"
-        />
-      </div>
-    </div>
-  </AuthenticatedLayout>
+    <AuthenticatedLayout>
+        <Head title="Dashboard" />
+        <div class="py-12">
+            <div class="mx-auto max-w-7xl sm:px-6 lg:px-8 space-y-4">
+                <DashboardTabs @update:modelValue="clearSelectedStock">
+                    
+                    <template #crypto>
+                        <CryptoTable :data="page.props.dashboardLists.cryptoList" />
+                    </template>
+
+                    <template #stocks>
+                        <div v-if="isLoadingStock" class="text-center p-10">Loading data...</div>
+                        
+                        <div v-else-if="!selectedStock">
+                            <div class="max-w-4xl mx-auto">
+                                <FgiCard :data="page.props.marketData.fearAndGreed" />
+                            </div>
+                            <StocksTable 
+                                :data="page.props.dashboardLists.stocksList" 
+                                @view-stock="viewStockDetail"
+                            />
+                        </div>
+                        
+                        <div v-else>
+                            <StockDetail v-bind="selectedStock" />
+                        </div>
+                    </template>
+
+                    <template #merval><BondsTab /></template>
+                    <template #bonds><BondsTab /></template>
+                    <template #options><OptionsTab /></template>
+                    <template #webhook><WebhookTab /></template>
+                </DashboardTabs>
+            </div>
+        </div>
+    </AuthenticatedLayout>
 </template>

--- a/resources/js/stores/dashboard.ts
+++ b/resources/js/stores/dashboard.ts
@@ -1,0 +1,48 @@
+import { defineStore } from 'pinia'
+  import { ref, computed, type Ref } from 'vue'
+  import type { StockOrCryptoItem } from '@/types/stock'
+
+  export interface MarketData {
+    fearAndGreed: unknown | null
+  }
+
+  export interface DashboardLists {
+    cryptoList: StockOrCryptoItem[]
+    stocksList: StockOrCryptoItem[]
+  }
+
+  /* ───── Store ───── */
+  export const useDashboardStore = defineStore('dashboard', () => {
+    const cryptoList: Ref<StockOrCryptoItem[]> = ref([])
+    const stocksList: Ref<StockOrCryptoItem[]> = ref([])
+    const marketData = ref<MarketData | null>(null)
+
+    const isHydrated     = computed(() => cryptoList.value.length > 0 || stocksList.value.length > 0)
+    const getCryptoList  = computed(() => cryptoList.value)
+    const getStocksList  = computed(() => stocksList.value)
+    const getMarketData  = computed(() => marketData.value)
+
+    function setData (data: Partial<DashboardLists & { marketData: MarketData | null }>) {
+      if (data.cryptoList)  cryptoList.value = data.cryptoList
+      if (data.stocksList)  stocksList.value = data.stocksList
+      if (Object.prototype.hasOwnProperty.call(data, 'marketData')) {
+        marketData.value = data.marketData ?? null
+      }
+    }
+
+    return {
+      // state
+      cryptoList,
+      stocksList,
+      marketData,
+
+      // actions
+      setData,
+
+      // getters
+      isHydrated,
+      getCryptoList,
+      getStocksList,
+      getMarketData,
+    }
+  })

--- a/resources/js/types/inertia.d.ts
+++ b/resources/js/types/inertia.d.ts
@@ -1,0 +1,16 @@
+import type { StockOrCryptoItem } from '@/types/stock';
+
+export interface SharedProps {
+  auth: any;
+  dashboardLists: {
+    cryptoList: StockOrCryptoItem[];
+    stocksList: StockOrCryptoItem[];
+  };
+  marketData: {
+    fearAndGreed: any | null;
+  };
+}
+
+declare module '@inertiajs/core' {
+  interface PageProps extends SharedProps {}
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,10 @@ Route::middleware('auth')->group(function () {
     Route::get('/dashboard', [DashboardController::class, 'index'])->name('dashboard');
     Route::get('/stocks', [StockController::class, 'index'])->name('stocks.index');
 
+
+    // Stock Details
+    Route::get('/stock-data/{symbol}', [StockController::class, 'show'])->name('stock.show');
+
     //Options
     Route::post('/options/process', [OptionsController::class, 'processMarketData'])->name('options.process');
 });


### PR DESCRIPTION
This commit refactors the dashboard's asset exploration flow to provide a true Single-Page Application (SPA) experience.

Previously, clicking on an asset triggered a full Inertia page navigation, which was disruptive to the user experience and caused a loss of context within the main dashboard tabs.

This new implementation adopts a "Stateful Container Component" pattern:
- The main `Dashboard.vue` component now manages the local state.
- A new internal API endpoint (`GET /stock-data/{symbol}`) has been added to fetch asset details as JSON, without a full page load.
- The `StocksTable.vue` component now emits an event on row click instead of navigating.
- `Dashboard.vue` listens for this event, fetches the data via axios, and dynamically renders the `StockDetail.vue` component in place using a v-if directive.

This results in a fluid, seamless user experience, keeping the user within the `/dashboard` context at all times while viewing details.